### PR TITLE
Changed to using function argument

### DIFF
--- a/tspng/extraction.py
+++ b/tspng/extraction.py
@@ -1,4 +1,4 @@
-#import statements
+# import statements
 import io
 import json
 import os
@@ -10,23 +10,30 @@ from tspng import MIME_TYPE
 from typing import Dict, List, Union
 from urllib.parse import urlparse
 
-def _open_image(file_or_bytes: Union[str, io.BytesIO], mime_type: str=MIME_TYPE) -> Dict:
-    #open
-    im=Image.open(file_or_bytes)
-    if im.format != 'PNG':
+
+def _open_image(
+    file_or_bytes: Union[str, io.BytesIO], mime_type: str = MIME_TYPE
+) -> Dict:
+    # open
+    im = Image.open(file_or_bytes)
+    if im.format != "PNG":
         raise Exception("Image is not a PNG.")
-    meta=im.text
-    #load
+    meta = im.text
+    # load
     if mime_type in meta.keys():
-        d=json.loads(meta[mime_type])
+        d = json.loads(meta[mime_type])
     else:
-        #warn if file has no embedded data
+        # warn if file has no embedded data
         warnings.warn(f"{file_or_bytes} has no embedded TS metadata.")
-        d={}
+        d = {}
     return d
 
-def extract(file_bytes_files_or_url: Union[str, io.BytesIO, List[str]], mime_type: str=MIME_TYPE) -> Dict:
-    '''
+
+def extract(
+    file_bytes_files_or_url: Union[str, io.BytesIO, List[str]],
+    mime_type: str = MIME_TYPE,
+) -> Dict:
+    """
     Returns the metadata from a TSPNG file as a dictionary.
 
         Parameters:
@@ -39,23 +46,28 @@ def extract(file_bytes_files_or_url: Union[str, io.BytesIO, List[str]], mime_typ
 
         Raises:
                 TypeError: If not a BytesIO object, file, list of files, or folder
-    '''
-    #call appropriate function
+    """
+    # call appropriate function
     if isinstance(file_bytes_files_or_url, io.BytesIO):
-        return extract_from_bytes(file_bytes_files_or_url, MIME_TYPE)
-    elif type(file_bytes_files_or_url) == str and os.path.isfile(file_bytes_files_or_url):
-        return extract_from_file(file_bytes_files_or_url, MIME_TYPE)
+        return extract_from_bytes(file_bytes_files_or_url, mime_type)
+    elif type(file_bytes_files_or_url) == str and os.path.isfile(
+        file_bytes_files_or_url
+    ):
+        return extract_from_file(file_bytes_files_or_url, mime_type)
     elif isinstance(file_bytes_files_or_url, list):
-        return extract_from_files(file_bytes_files_or_url, MIME_TYPE)
+        return extract_from_files(file_bytes_files_or_url, mime_type)
     elif os.path.isdir(file_bytes_files_or_url):
-        return extract_from_folder(file_bytes_files_or_url, MIME_TYPE)
-    elif urlparse(file_bytes_files_or_url)[0] != '':
-        return extract_from_url(file_bytes_files_or_url, MIME_TYPE)
+        return extract_from_folder(file_bytes_files_or_url, mime_type)
+    elif urlparse(file_bytes_files_or_url)[0] != "":
+        return extract_from_url(file_bytes_files_or_url, mime_type)
     else:
-        raise TypeError(f"{file_bytes_files_or_url} is not a BytesIO object, file, list of files, or folder.")
+        raise TypeError(
+            f"{file_bytes_files_or_url} is not a BytesIO object, file, list of files, or folder."
+        )
 
-def extract_from_bytes(buffer: io.BytesIO, mime_type: str=MIME_TYPE) -> Dict:
-    '''
+
+def extract_from_bytes(buffer: io.BytesIO, mime_type: str = MIME_TYPE) -> Dict:
+    """
     Returns the metadata from a TS byte stream as a dictionary.
 
         Parameters:
@@ -69,14 +81,15 @@ def extract_from_bytes(buffer: io.BytesIO, mime_type: str=MIME_TYPE) -> Dict:
         Raises:
                 TypeError: If buffer is not BytesIO
                 Exception: If image is not a PNG
-    '''
-    #check if file is BytesIO
+    """
+    # check if file is BytesIO
     if not isinstance(buffer, io.BytesIO):
         raise TypeError(f"{buffer} is not a BytesIO object.")
-    return _open_image(buffer,mime_type)
+    return _open_image(buffer, mime_type)
 
-def extract_from_file(path: str, mime_type: str=MIME_TYPE) -> Dict:
-    '''
+
+def extract_from_file(path: str, mime_type: str = MIME_TYPE) -> Dict:
+    """
     Returns the metadata from a TSPNG file as a dictionary.
 
         Parameters:
@@ -91,17 +104,18 @@ def extract_from_file(path: str, mime_type: str=MIME_TYPE) -> Dict:
                 Exception: If path does not exist
                 Exception: If path is not a file
                 Exception: If image is not a PNG
-    '''
-    #checks if path exists
+    """
+    # checks if path exists
     if not os.path.exists(path):
         raise Exception(f"{path} does not exist.")
-    #check if file exists
+    # check if file exists
     if not os.path.isfile(path):
         raise Exception(f"The {path} is not a file.")
-    return _open_image(path,mime_type)
+    return _open_image(path, mime_type)
 
-def extract_from_files(paths: List[str], mime_type: str=MIME_TYPE) -> Dict:
-    '''
+
+def extract_from_files(paths: List[str], mime_type: str = MIME_TYPE) -> Dict:
+    """
     Returns a nested dictionary of metadata from a list of TSPNG file paths.
 
         Parameters:
@@ -111,14 +125,15 @@ def extract_from_files(paths: List[str], mime_type: str=MIME_TYPE) -> Dict:
 
         Returns:
                 (dict): Dictionary containing metadata of each file
-    '''
+    """
     nested_dict = {}
     for path in paths:
         nested_dict[path] = extract_from_file(path, mime_type)
     return nested_dict
 
-def extract_from_folder(path: str, mime_type: str=MIME_TYPE) -> Dict:
-    '''
+
+def extract_from_folder(path: str, mime_type: str = MIME_TYPE) -> Dict:
+    """
     Returns a nested dictionary of metadata from a folder of TSPNG file paths.
 
         Parameters:
@@ -132,8 +147,8 @@ def extract_from_folder(path: str, mime_type: str=MIME_TYPE) -> Dict:
         Raises:
                 Exception: If path is not a directory
                 Exception: If path does not contain a PNG file
-    '''
-    #check if directory
+    """
+    # check if directory
     if not os.path.isdir(path):
         raise Exception(f"The {path} is not to a directory.")
     # return all files as a list
@@ -141,16 +156,17 @@ def extract_from_folder(path: str, mime_type: str=MIME_TYPE) -> Dict:
     for file in os.listdir(path):
         # check the files which are end with specific extension
         root_ext = os.path.splitext(file)
-        if root_ext[1] == '.png':
+        if root_ext[1] == ".png":
             # print path name of selected files
             file_list.append(os.path.join(path, file))
-    #check if any PNG files in directory
+    # check if any PNG files in directory
     if file_list == []:
         raise Exception(f"The {path} does not contain a PNG file.")
     return extract_from_files(file_list, mime_type)
 
-def extract_from_url(url: str, mime_type: str=MIME_TYPE) -> Dict:
-    '''
+
+def extract_from_url(url: str, mime_type: str = MIME_TYPE) -> Dict:
+    """
     Returns the metadata from a TS url as a dictionary.
 
         Parameters:
@@ -163,10 +179,12 @@ def extract_from_url(url: str, mime_type: str=MIME_TYPE) -> Dict:
 
         Raises:
                 Exception: If cannot get image from url
-    '''
+    """
     response = urllib.request.urlopen(url)
     if response.getcode() == 200:
         img_data = response.read()
     else:
-        raise Exception(f"Failed to fetch image from {url}. Status code: {response.getcode()}")
+        raise Exception(
+            f"Failed to fetch image from {url}. Status code: {response.getcode()}"
+        )
     return _open_image(io.BytesIO(img_data), mime_type)


### PR DESCRIPTION
The `mime_type` function argument was not used. The `MIME_TYPE` constant was used. This changes to using the function argument to make the function more flexible.