### PR TITLE
Fixed automated publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,14 +5,16 @@ on:
     types: [published]
 jobs:
   pypi:
+    name: Upload release to PyPI
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - run: python3 -m pip install --upgrade build && python3 -m build
-      - name: Publish package
+      - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Resolves #76.

Followed the instructions at https://docs.pypi.org/trusted-publishers/using-a-publisher/ and https://docs.pypi.org/trusted-publishers/adding-a-publisher/.